### PR TITLE
Made register works with exports

### DIFF
--- a/src/macro-assertions.ts
+++ b/src/macro-assertions.ts
@@ -155,7 +155,11 @@ export function getTypeDeclarationInBlock(
 ): t.TSInterfaceDeclaration | t.TSTypeAliasDeclaration | null {
   for (let i = 0; i < stmts.length; ++i) {
     if (i === idxInBlock) continue;
-    const stmt = stmts[i];
+    let stmt = stmts[i];
+    // If the statement is an export (named or default) use the declared statement instead
+    if (t.isExportNamedDeclaration(stmt) || t.isExportDefaultDeclaration(stmt)) {
+      stmt = stmt.declaration;
+    }
     if (t.isTSInterfaceDeclaration(stmt) || t.isTSTypeAliasDeclaration(stmt)) {
       const declarationName = stmt.id.name;
       if (declarationName === typeName) {

--- a/src/macro-assertions.ts
+++ b/src/macro-assertions.ts
@@ -157,7 +157,10 @@ export function getTypeDeclarationInBlock(
     if (i === idxInBlock) continue;
     let stmt = stmts[i];
     // If the statement is an export (named or default) use the declared statement instead
-    if (t.isExportNamedDeclaration(stmt) || t.isExportDefaultDeclaration(stmt)) {
+    if (
+      t.isExportNamedDeclaration(stmt) ||
+      t.isExportDefaultDeclaration(stmt)
+    ) {
       stmt = stmt.declaration;
     }
     if (t.isTSInterfaceDeclaration(stmt) || t.isTSTypeAliasDeclaration(stmt)) {


### PR DESCRIPTION
I wanted to use typecheck.macro in my new express project, but all my types are exported for other files to use.
Then I realized typecheck.macro won't register exports, so I forked it and made it work!