### PR TITLE
Update peerDependency to support babel-plugin-macros 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.9.6",
-    "babel-plugin-macros": "^2.8.0"
+    "babel-plugin-macros": "^2.8.0 || ^3.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
"Drop Node.js < 10 support" is the only breaking change between babel-plugin-macros 2 and 3.